### PR TITLE
Spark upgrade to 2.4.1 #2

### DIFF
--- a/firesteel/pom.xml
+++ b/firesteel/pom.xml
@@ -23,7 +23,7 @@
 	<groupId>com.hp.hpl</groupId>
 	<artifactId>firesteel</artifactId>
 	<packaging>jar</packaging>
-	<version>2.4.0</version>
+	<version>2.4.1</version>
 	<name>HP Labs Project Fire Steel</name>
 
 	<properties>
@@ -32,7 +32,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
                 <scala.version>2.11.12</scala.version>
                 <scala.binary.version>2.11</scala.binary.version>
-                <spark.version>2.4.0</spark.version>
+                <spark.version>2.4.1</spark.version>
                 <slf4j.version>1.7.5</slf4j.version>
                 <log4j.version>1.2.17</log4j.version>
                 <kryo.version>3.0.3</kryo.version>
@@ -67,7 +67,7 @@
         <dependency>  
             <groupId>org.apache.spark</groupId>  
             <artifactId>spark-core_${scala.binary.version}</artifactId>  
-            <version>2.4.0</version>  
+            <version>${spark.version}</version>
         </dependency> 
 
         <!-- this is the dependent networking library installed in the local repository-->
@@ -125,7 +125,6 @@
             <artifactId>kryo</artifactId>
             <version>${kryo.version}</version>
         </dependency>
-
     </dependencies>  
     
 	<build>

--- a/firesteel/pom.xml
+++ b/firesteel/pom.xml
@@ -33,15 +33,26 @@
                 <scala.version>2.11.12</scala.version>
                 <scala.binary.version>2.11</scala.binary.version>
                 <spark.version>2.4.1</spark.version>
-                <slf4j.version>1.7.5</slf4j.version>
+  <slf4j.version>1.7.16</slf4j.version>
                 <log4j.version>1.2.17</log4j.version>
-                <kryo.version>3.0.3</kryo.version>
+  <kryo.version>4.0.2</kryo.version>
                 <scala.tools.version>2.11</scala.tools.version>
                 <avro.mapred.classifier>hadoop2</avro.mapred.classifier>
                 <orbit.version>3.0.0.v201112011016</orbit.version>
                 <mesos.version>0.21.1</mesos.version>
                 <mesos.classifier>shaded-protobuf</mesos.classifier>
                 <oro.version>2.0.8</oro.version>
+
+  <junit.version>4.12</junit.version>
+  <scalatest.version>3.0.7</scalatest.version>
+
+  <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
+                <antrun.plugin.version>1.8</antrun.plugin.version>
+		<scala.plugin.version>2.14.2</scala.plugin.version>
+  <maven.scala.plugin.version>3.2.2</maven.scala.plugin.version>
+  <surefire.plugin.version>2.22.0</surefire.plugin.version>
+  <scalatest.plugin.version>1.0</scalatest.plugin.version>
+  <jar.plugin.version>3.0.2</jar.plugin.version>
                 <MaxPermGen>512m</MaxPermGen>
                 <!--by default, skip tests. to run the tests, issue in mvn: -DskipTests=false -->
                 <!--<skipTests>true</skipTests> -->
@@ -82,14 +93,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+    <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest_${scala.tools.version}</artifactId>
-          <version>3.0.5</version>
+    <version>${scalatest.version}</version>
           <scope>test</scope>
         </dependency>
 
@@ -119,10 +130,9 @@
             <version>${slf4j.version}</version>
         </dependency>
 
-        <!-- kryo serializer 3.0 is what we choose for compilation -->
         <dependency>
             <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
+    <artifactId>kryo-shaded</artifactId>
             <version>${kryo.version}</version>
         </dependency>
     </dependencies>  
@@ -132,7 +142,7 @@
            <plugin>  
                 <groupId>org.scala-tools</groupId>  
                 <artifactId>maven-scala-plugin</artifactId>  
-                <version>2.14.2</version>  
+                <version>${scala.plugin.version}</version>  
                 <executions>
                     <execution>
                         <goals>
@@ -147,7 +157,7 @@
             <plugin>
                <groupId>net.alchim31.maven</groupId>
                <artifactId>scala-maven-plugin</artifactId>
-               <version>3.1.3</version>
+               <version>${maven.scala.plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -168,6 +178,7 @@
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
+      <version>${maven.compiler.plugin.version}</version>
                <configuration>
                   <compilerArgs>
                    <!-- This option is needed to suppress warnings from sun.misc.Unsafe usage -->
@@ -187,7 +198,7 @@
 
 	    <plugin>
 		<artifactId>maven-antrun-plugin</artifactId>
-		<version>1.7</version>
+		<version>${antrun.plugin.version}</version>
 		<executions>
 		   <execution>
 		      <phase>process-classes</phase>
@@ -254,7 +265,7 @@
              <plugin>
                    <groupId>org.apache.maven.plugins</groupId>
                    <artifactId>maven-surefire-plugin</artifactId>
-                   <version>2.13</version>
+                   <version>${surefire.plugin.version}</version>
                    <configuration>
                          <argLine>-Xms16000m -Xmx16000m</argLine>
 
@@ -288,7 +299,7 @@
              <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>1.0</version>
+                <version>${scalatest.plugin.version}</version>
                 <configuration>
                   <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                   <junitxml>.</junitxml>
@@ -325,7 +336,7 @@
              <plugin>
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-jar-plugin</artifactId>
-                 <version>2.6</version>
+                 <version>${jar.plugin.version}</version>
                  <executions>
                     <execution>
                     <goals>

--- a/tests/multinodes/GroupBy/groupby.sbt
+++ b/tests/multinodes/GroupBy/groupby.sbt
@@ -18,11 +18,10 @@ version := "2.0"
 
 scalaVersion := "2.11.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.3"
 
 resolvers += Resolver.mavenLocal
 
 resolvers += "Akka Repository" at "http://repo.akka.io/releases/"
-

--- a/tests/multinodes/Join/join.sbt
+++ b/tests/multinodes/Join/join.sbt
@@ -18,11 +18,10 @@ version := "1.0"
 
 scalaVersion := "2.11.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.3"
 
 resolvers += Resolver.mavenLocal
 
 resolvers += "Akka Repository" at "http://repo.akka.io/releases/"
-

--- a/tests/multinodes/PageRank/pagerank.sbt
+++ b/tests/multinodes/PageRank/pagerank.sbt
@@ -18,7 +18,7 @@ version := "3.0"
 
 scalaVersion := "2.11.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.1"
 
 resolvers += Resolver.mavenLocal
 

--- a/tests/multinodes/PartitionBy/partitionby.sbt
+++ b/tests/multinodes/PartitionBy/partitionby.sbt
@@ -18,9 +18,9 @@ version := "1.0"
 
 scalaVersion := "2.11.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.3"
 
 resolvers += Resolver.mavenLocal
 

--- a/tests/multinodes/ReduceBy/reduceby.sbt
+++ b/tests/multinodes/ReduceBy/reduceby.sbt
@@ -18,9 +18,9 @@ version := "1.0"
 
 scalaVersion := "2.11.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.3"
 
 resolvers += Resolver.mavenLocal
 

--- a/tests/multinodes/SortBy/sortby.sbt
+++ b/tests/multinodes/SortBy/sortby.sbt
@@ -18,9 +18,9 @@ version := "1.0"
 
 scalaVersion := "2.11.12"
 
-libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0"
+libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.1"
 
-libraryDependencies += "org.scalatest" % "scalatest_2.11" % "2.2.1"
+libraryDependencies += "org.scalatest" % "scalatest_2.11" % "3.0.3"
 
 resolvers += Resolver.mavenLocal
 

--- a/tests/multinodes/TeraSort/README.md
+++ b/tests/multinodes/TeraSort/README.md
@@ -17,7 +17,7 @@
     to the sub-directory "spark-terasort"
 
 (2) to compile the terasort code: 
-    mvn -Dhadoop.version=2.4.0 clean package 
+    mvn -Dhadoop.version=2.4.1 clean package 
 
 
 (3) make sure that the shared-memory has been created by ALPS tool, for example

--- a/tests/multinodes/TeraSort/spark-terasort/pom.xml
+++ b/tests/multinodes/TeraSort/spark-terasort/pom.xml
@@ -218,9 +218,9 @@
 
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <scala.version>2.11.8</scala.version>
+  <scala.version>2.11.12</scala.version>
   <scala.binary.version>2.11</scala.binary.version>
-  <spark.version>2.0.0-SNAPSHOT</spark.version>
+  <spark.version>2.4.1</spark.version>
 </properties>
 
 <dependencies>


### PR DESCRIPTION
What this PR includes:

Bump Apache Spark to v2.4.1.
Also upgrade Spark dependent jars conforming to Spark Core's pom.xml.